### PR TITLE
Upgrading the Service Remoting to v2

### DIFF
--- a/SFKV.Contracts/IStore.cs
+++ b/SFKV.Contracts/IStore.cs
@@ -1,7 +1,8 @@
 ﻿using System.Threading.Tasks;
-
 using Microsoft.ServiceFabric.Services.Remoting;
+using Microsoft.ServiceFabric.Services.Remoting.FabricTransport;
 
+[assembly: FabricTransportServiceRemotingProvider(RemotingListener = RemotingListener.V2Listener, RemotingClient = RemotingClient.V2Client)]
 namespace SFKV.Contracts
 {
     /// <summary>

--- a/SFKV.Store/PackageRoot/ServiceManifest.xml
+++ b/SFKV.Store/PackageRoot/ServiceManifest.xml
@@ -28,7 +28,7 @@
       <!-- This endpoint is used by the communication listener to obtain the port on which to 
            listen. Please note that if your service is partitioned, this port is shared with 
            replicas of different partitions that are placed in your code. -->
-      <Endpoint Name="ServiceEndpoint" />
+      <Endpoint Name="ServiceEndpointV2" />
 
       <!-- This endpoint is used by the replicator for replicating the state of your service.
            This endpoint is configured through a ReplicatorSettings config section in the Settings.xml

--- a/SFKV.Store/Store.cs
+++ b/SFKV.Store/Store.cs
@@ -4,11 +4,10 @@ using System.Fabric;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.ServiceFabric.Data.Collections;
 using Microsoft.ServiceFabric.Services.Communication.Runtime;
 using Microsoft.ServiceFabric.Services.Runtime;
-using Microsoft.ServiceFabric.Services.Remoting.Runtime;
 using SFKV.Contracts;
+using Microsoft.ServiceFabric.Services.Remoting.V2.FabricTransport.Runtime;
 
 namespace SFKV.Store
 {
@@ -39,7 +38,10 @@ namespace SFKV.Store
         {
             return new[]
             {
-                new ServiceReplicaListener(context => this.CreateServiceRemotingListener(context), "RpcEndpoint", true)
+                new ServiceReplicaListener(
+                    (c) => new FabricTransportServiceRemotingListener(c, this),
+                    "V2Listener", 
+                    listenOnSecondary: true)
             };
         }
 

--- a/SFKV/ApplicationParameters/Cloud.xml
+++ b/SFKV/ApplicationParameters/Cloud.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/SFKV" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
-    <Parameter Name="SFKV.Store_PartitionCount" Value="1" />
+    <Parameter Name="SFKV.Store_PartitionCount" Value="2" />
     <Parameter Name="SFKV.Store_MinReplicaSetSize" Value="3" />
     <Parameter Name="SFKV.Store_TargetReplicaSetSize" Value="3" />
   </Parameters>

--- a/SFKV/ApplicationParameters/Local.5Node.xml
+++ b/SFKV/ApplicationParameters/Local.5Node.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/SFKV" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
-    <Parameter Name="SFKV.Store_PartitionCount" Value="1" />
+    <Parameter Name="SFKV.Store_PartitionCount" Value="2" />
     <Parameter Name="SFKV.Store_MinReplicaSetSize" Value="3" />
     <Parameter Name="SFKV.Store_TargetReplicaSetSize" Value="3" />
   </Parameters>


### PR DESCRIPTION
- Updated the default partition count to 2.
- Upgrading the IStore contract to use assembly attribute that specify client to use v2 remoting.
- Upgrading the listener to use Service Remoting v2. 
#9  